### PR TITLE
As 6580/facets improvement

### DIFF
--- a/localPackages/altitude-commercetools-connector/src/category.js
+++ b/localPackages/altitude-commercetools-connector/src/category.js
@@ -20,7 +20,7 @@ async function getPageData({ params, req, locale }) {
   const filterQuery = (filterKey && `${filterKey}:${req.query[filterKey]}`) || ''
   const { categorySlug } = req.query
 
-  const facets = await getContentFulClient().getFacets(locale)
+  const facets = await getContentFulClient().getFacets({locale})
   const { body: category } = await getCategoryById({ categoryId: categorySlug[0] })
   const plp = await getProductsByCategoryId({ categoryId: categorySlug[0], facets, filterQuery })
 

--- a/localPackages/altitude-commercetools-connector/src/category.js
+++ b/localPackages/altitude-commercetools-connector/src/category.js
@@ -20,17 +20,9 @@ async function getPageData({ params, req, locale }) {
   const filterQuery = (filterKey && `${filterKey}:${req.query[filterKey]}`) || ''
   const { categorySlug } = req.query
 
-  const facetResponse = await getContentFulClient().getFacets(locale)
-  const formattedFacet = facetResponse.map(facet => ({...facet, field: `variants.attributes.${facet.field}`}))
-  const facet = formattedFacet.map(f => f.field)
-
+  const facets = await getContentFulClient().getFacets(locale)
   const { body: category } = await getCategoryById({ categoryId: categorySlug[0] })
-  const plp = await getProductsByCategoryId({ categoryId: categorySlug[0], facet, filterQuery })
-
-  const plpFacets = plp.facets.map(f => ({
-    ...f,
-    name: formattedFacet.find(ff => ff.field === f.name).label
-  }))
+  const plp = await getProductsByCategoryId({ categoryId: categorySlug[0], facets, filterQuery })
 
   const categoryName = category.name[locale]
   // collect all page data
@@ -49,6 +41,5 @@ async function getPageData({ params, req, locale }) {
       },
     ],
     ...plp,
-    facets: plpFacets
   }
 }

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/commercetoolsClient.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/commercetoolsClient.ts
@@ -7,26 +7,26 @@ import { CreateQueryType, ProductsByCategoryIdRequestType, type PlpResponse } fr
 import { normalizePlp } from './mappers/normalizePlp'
 const apiRoot = createApiBuilderFromCtpClient(ctpClient);
 
-const getProductsByCategoryId = async ({ req= {}, params= {}, categoryId='', facet=[], filterQuery='' }: ProductsByCategoryIdRequestType): Promise<PlpResponse> => {
+const getProductsByCategoryId = async ({ req= {}, params= {}, categoryId='', facets=[], filterQuery='' }: ProductsByCategoryIdRequestType): Promise<PlpResponse> => {
   try {
     const { body: search } = await apiRoot
       .withProjectKey({ projectKey })
       .productProjections()
       .search()
-      .get(createQueryWith({categoryId, facet, filterQuery }))
+      .get(createQueryWith({categoryId, facets, filterQuery }))
       .execute();
 
-    return normalizePlp(search);
+    return normalizePlp(search, facets);
 
   } catch (error) {
     console.error(error);
   }
 };
 
-const createQueryWith = ({categoryId, facet, filterQuery}: CreateQueryType) => {
+const createQueryWith = ({categoryId, facets, filterQuery}: CreateQueryType) => {
   const query = {
     queryArgs: {
-      facet,
+      facet: facets.map(f => f.field),
       filter: [`categories.id:"${categoryId}"`],
     }
   }

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/commercetoolsClient.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/commercetoolsClient.ts
@@ -7,13 +7,13 @@ import { CreateQueryType, ProductsByCategoryIdRequestType, type PlpResponse } fr
 import { normalizePlp } from './mappers/normalizePlp'
 const apiRoot = createApiBuilderFromCtpClient(ctpClient);
 
-const getProductsByCategoryId = async ({ req= {}, params= {}, categoryId='', filterQuery='' }: ProductsByCategoryIdRequestType): Promise<PlpResponse> => {
+const getProductsByCategoryId = async ({ req= {}, params= {}, categoryId='', facet=[], filterQuery='' }: ProductsByCategoryIdRequestType): Promise<PlpResponse> => {
   try {
     const { body: search } = await apiRoot
       .withProjectKey({ projectKey })
       .productProjections()
       .search()
-      .get(createQueryWith({categoryId, filterQuery }))
+      .get(createQueryWith({categoryId, facet, filterQuery }))
       .execute();
 
     return normalizePlp(search);
@@ -23,10 +23,10 @@ const getProductsByCategoryId = async ({ req= {}, params= {}, categoryId='', fil
   }
 };
 
-const createQueryWith = ({categoryId='', filterQuery=''}: CreateQueryType) => {
+const createQueryWith = ({categoryId, facet, filterQuery}: CreateQueryType) => {
   const query = {
     queryArgs: {
-      facet: ['variants.attributes.vendorTitle', 'variants.attributes.test'], // TODO: avoid hardcoding
+      facet,
       filter: [`categories.id:"${categoryId}"`],
     }
   }

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/mappers/normalizeFacets.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/mappers/normalizeFacets.ts
@@ -1,10 +1,10 @@
 import { FacetResponseType, PlpFacetOptionsType, PlpFacetType } from "../types/facets"
 
 
-const normalizeFacets = (facets: FacetResponseType): PlpFacetType[] =>
-  Object.keys(facets).map(key => ({
-    name: key,
-    options: normalizeFacetsTerms(key, facets),
+const normalizeFacets = (facetResponse: FacetResponseType, facet: any[]): PlpFacetType[] =>
+  Object.keys(facetResponse).map(key => ({
+    name: facet.find(f => f.field === key).label,
+    options: normalizeFacetsTerms(key, facetResponse),
     ui: "checkboxes"
   }))
 

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/mappers/normalizeFacets.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/mappers/normalizeFacets.ts
@@ -1,7 +1,8 @@
+import { ContentfulFacetResponse } from "../types"
 import { FacetResponseType, PlpFacetOptionsType, PlpFacetType } from "../types/facets"
 
 
-const normalizeFacets = (facetResponse: FacetResponseType, facet: any[]): PlpFacetType[] =>
+const normalizeFacets = (facetResponse: FacetResponseType, facet: ContentfulFacetResponse[]): PlpFacetType[] =>
   Object.keys(facetResponse).map(key => ({
     name: facet.find(f => f.field === key).label,
     options: normalizeFacetsTerms(key, facetResponse),

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/mappers/normalizePlp.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/mappers/normalizePlp.ts
@@ -3,7 +3,7 @@ import { type PlpResponse } from './../types/index'
 import { normalizeFacets } from './normalizeFacets'
 import normalizeProduct from './normalizeProduct'
 
-export function normalizePlp(search): PlpResponse {
+export function normalizePlp(search, facets): PlpResponse {
   // TODO: Limit needs to be a config param
   const limit = 24
   // TODO: Check logic in client side, it is adding an additional page
@@ -11,7 +11,7 @@ export function normalizePlp(search): PlpResponse {
 
   const { results = [] } = search
   let products = []
-  const facets: FacetResponseType = search.facets || {}
+  const facetsResponse: FacetResponseType = search.facets || {}
 
   if (results.length > 0) {
       products = results
@@ -25,6 +25,6 @@ export function normalizePlp(search): PlpResponse {
     // sort,
     sortOptions: [],
     filters: [],
-    facets: normalizeFacets(facets),
+    facets: normalizeFacets(facetsResponse, facets),
   }
 }

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/types/index.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/types/index.ts
@@ -23,11 +23,17 @@ export type ProductsByCategoryIdRequestType = {
     }
     filterQuery: string;
     categoryId: string;
-    facets: string[];
+    facets: ContentfulFacetResponse[];
 }
 
 export type CreateQueryType = {
     categoryId: string;
     filterQuery: string;
-    facets: any[];
+    facets: ContentfulFacetResponse[];
 }
+
+export type ContentfulFacetResponse = {
+    field: string;
+    type: 'list'|'hierarchy'|'grid';
+    label: string;
+  }

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/types/index.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/types/index.ts
@@ -23,11 +23,11 @@ export type ProductsByCategoryIdRequestType = {
     }
     filterQuery: string;
     categoryId: string;
-    facet: string[];
+    facets: string[];
 }
 
 export type CreateQueryType = {
     categoryId: string;
     filterQuery: string;
-    facet: string[];
+    facets: any[];
 }

--- a/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/types/index.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/commercetools-v2/types/index.ts
@@ -23,9 +23,11 @@ export type ProductsByCategoryIdRequestType = {
     }
     filterQuery: string;
     categoryId: string;
+    facet: string[];
 }
 
 export type CreateQueryType = {
     categoryId: string;
-    filterQuery: string
+    filterQuery: string;
+    facet: string[];
 }

--- a/localPackages/altitude-commercetools-connector/src/clients/contentful/contentful-client.js
+++ b/localPackages/altitude-commercetools-connector/src/clients/contentful/contentful-client.js
@@ -27,19 +27,19 @@ export default function getContentFulClient(req) {
       `https://graphql.contentful.com/content/v1/spaces/${spaceId}?access_token=${accessToken}`,
       {
         query: `query {
-                categoryCollection {
+                  categoryCollection {
                     items {
-                        sys { id }
-                        name: name(locale: "${locale}")
-                        slug
-                        parentCategoriesCollection{
-                            items{
-                                sys { id }
-                            }
+                      sys { id }
+                      name: name(locale: "${locale}")
+                      slug
+                      parentCategoriesCollection{
+                        items{
+                          sys { id }
                         }
+                      }
                     }
-                }
-            }`,
+                  }
+                }`,
       }
     )
 
@@ -69,6 +69,25 @@ export default function getContentFulClient(req) {
     return _categoryTree
   }
 
+  const getFacets = async ({ locale = 'en-CA' } = {}) => {
+    const { data } = await Axios.post(
+      `https://graphql.contentful.com/content/v1/spaces/${spaceId}?access_token=${accessToken}`,
+      {
+        query: `query {
+                  facetsCollection {
+                    items {
+                      field
+                      label: label(locale: "${locale}")
+                      type
+                    }
+                  }
+                }`,
+      }
+    )
+
+    return data.data.facetsCollection.items || [];
+  }
+
   let _collectionPaths = new Map()
   const getCollectionPaths = async () => {
     if (_collectionPaths.size === 0) {
@@ -95,5 +114,6 @@ export default function getContentFulClient(req) {
     getEntry,
     getCategoryTree,
     getCollectionPaths,
+    getFacets,
   }
 }

--- a/localPackages/altitude-commercetools-connector/src/clients/contentful/contentful-client.js
+++ b/localPackages/altitude-commercetools-connector/src/clients/contentful/contentful-client.js
@@ -84,8 +84,10 @@ export default function getContentFulClient(req) {
                 }`,
       }
     )
+    const facets = data.data.facetsCollection
 
-    return data.data.facetsCollection.items || [];
+    if (!facets) return []
+    return facets.items.map(f => ({...f, field: `variants.attributes.${f.field}`}));
   }
 
   let _collectionPaths = new Map()

--- a/localPackages/altitude-commercetools-connector/src/clients/contentful/contentful-client.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/contentful/contentful-client.ts
@@ -69,7 +69,7 @@ export default function getContentFulClient(req) {
     return _categoryTree
   }
 
-  const getFacets = async ({ locale = 'en-CA' } = {}) => {
+  const getFacets = async ({ locale = 'en-CA' } = {}): Promise<FacetResponse[]> => {
     const { data } = await Axios.post(
       `https://graphql.contentful.com/content/v1/spaces/${spaceId}?access_token=${accessToken}`,
       {
@@ -90,32 +90,9 @@ export default function getContentFulClient(req) {
     return facets.items.map(f => ({...f, field: `variants.attributes.${f.field}`}));
   }
 
-  let _collectionPaths = new Map()
-  const getCollectionPaths = async () => {
-    if (_collectionPaths.size === 0) {
-      const tree = await getCategoryTree()
-
-      const recursivelyProcessChildren = (c, parentPath = '') => {
-        for (const category of c) {
-          const path = `${parentPath}/${category.slug}&facets=${category.facets}`
-          collection.set(path, category)
-
-          if (category.children && category.children.length > 0) {
-            recursivelyProcessChildren(category.children, path)
-          }
-        }
-      }
-
-      recursivelyProcessChildren(tree)
-    }
-
-    return _collectionPaths
-  }
-
   return {
     getEntry,
     getCategoryTree,
-    getCollectionPaths,
     getFacets,
   }
 }

--- a/localPackages/altitude-commercetools-connector/src/clients/contentful/types/facet.type.ts
+++ b/localPackages/altitude-commercetools-connector/src/clients/contentful/types/facet.type.ts
@@ -1,0 +1,5 @@
+type FacetResponse = {
+  field: string;
+  type: 'list'|'hierarchy'|'grid';
+  label: string;
+}


### PR DESCRIPTION
Ticket: https://altitude-sports.atlassian.net/browse/AS-6580

## Description:

Avoid hardcoding the facets used to fetch to CT. So I did:
- add facet attributes to products [HERE](https://mc.us-central1.gcp.commercetools.com/alti-poc/products)
- create facets [HERE](https://app.contentful.com/spaces/dli1gm1g4047/entries?id=Qc1v7P9XYYYZ9PbI&order.fieldId=updatedAt&order.direction=descending&contentTypeId=facets&displayedFieldIds=contentType&displayedFieldIds=updatedAt&displayedFieldIds=author&folderId=YZq2Iv7XEq25pHNJ&page=0)

Then:

- fetch all facets to CF
- use them to fetch those facets to CT
- show the result in a user-friendly way
- extra: improve typescript usage

## How to test it?
- play with facets in CF and CT
- use the app and observe 

## Demo

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/11604761/188214548-0e642ac7-b4d9-4ecf-a865-2e275972fea5.png">
